### PR TITLE
chore: wire admin gcp key through docker secrets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,15 @@ services:
       - "8080:8080"
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      NLP_GOOGLE_CREDENTIALS_LOCATION: file:/run/secrets/gcp_key_json
       SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: 2
       SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: 1
       SPRING_DATASOURCE_HIKARI_IDLE_TIMEOUT: 10000
       SPRING_DATASOURCE_HIKARI_MAX_LIFETIME: 30000
       SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT: 30000
 
+    secrets:
+      - gcp_key_json
     depends_on:
       kafka:
         condition: service_healthy


### PR DESCRIPTION
admin 서비스에 google ai api 추가 하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 내용 분석

**Docker Compose 설정 업데이트**
- `backend-admin` 서비스에 Google NLP API 크리덴셜 환경 변수 추가: `NLP_GOOGLE_CREDENTIALS_LOCATION: file:/run/secrets/gcp_key_json`
- Docker secrets를 통한 보안 매운트: `secrets: - gcp_key_json`
- 최상단 secrets 정의로 `./secrets/gcp-key.json` 파일을 런타임에 주입

## 긍정적 평가

✅ **보안 관행**: Docker secrets를 활용하여 민감한 크리덴셜 정보를 안전하게 관리하는 좋은 접근입니다. 환경 변수 노출 대신 파일 기반 주입으로 보안이 강화되었습니다.

✅ **일관성**: `backend-batch` 서비스도 동일하게 `NLP_GOOGLE_CREDENTIALS_LOCATION` 설정을 사용하고 있어, 여러 마이크로서비스 간 Google AI 통합이 일관되게 적용되어 있습니다.

## 개선 제안

📋 **확인 필요 사항**:
1. `.gitignore` 파일에 `secrets/gcp-key.json`이 확실히 등록되어 있는지 확인 바랍니다. (실수로 커밋되지 않도록 방지)
2. 개발 환경용 더미 크리덴셜 파일(`./secrets/gcp-key.json.example` 등)이 리포지토리에 있으면, 팀원들이 로컬 개발 환경 설정 시 참고할 수 있습니다.
3. README나 설정 가이드 문서에 "GCP 키 설정 방법" 섹션이 있으면 온보딩이 용이합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->